### PR TITLE
Written the recommended extensions for VSC

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "serayuzgur.crates",
+    "bungcip.better-toml",
+    "rust-lang.rust-analyzer"
+  ]
+}

--- a/kernel/src/init.rs
+++ b/kernel/src/init.rs
@@ -1,5 +1,3 @@
-use core::mem;
-
 use alloc::vec::Vec;
 use bootloader::BootInfo;
 use lazy_static::lazy_static;
@@ -16,12 +14,9 @@ use crate::{
 #[cfg(debug_assertions)]
 use crate::debug;
 
-pub type SysCallHandlerFunc = extern "C" fn(*const u8);
 lazy_static! {
     static ref REGISTERED_DRIVERS: Mutex<Vec<Registrator>> = Mutex::new(Vec::new());
     static ref INITIALIZED_DRIVERS: Mutex<Vec<Driver>> = Mutex::new(Vec::new());
-    static ref SYSCALLS: Mutex<[SysCallHandlerFunc; 256]> =
-        Mutex::new([unsafe { mem::transmute(0u8 as *const ()) }; 256]);
 }
 
 /// Initialises the components of the OS, **must** be called before any other functions.
@@ -32,7 +27,7 @@ pub fn init(boot_info: &'static BootInfo) -> KernelInformation {
     let kernel_info = KernelInformation::new(boot_info);
     interrupts::reload_gdt();
     interrupts::init_idt();
-    interrupts::setup_syscalls();
+    interrupts::syscalls::setup_syscalls();
     interrupts::enable();
 
     kernel_info
@@ -53,10 +48,6 @@ pub fn reload_drivers(kernel_info: KernelInformation) {
 /// Registers a driver. After registering drivers call reload_drivers to initialize them.
 pub fn register_driver(registrator: Registrator) {
     REGISTERED_DRIVERS.lock().push(registrator);
-}
-
-pub fn register_syscall(syscall_number: u8, handler: SysCallHandlerFunc) {
-    SYSCALLS.lock()[syscall_number as usize] = handler;
 }
 
 /// Endless loop calling halt continuously.

--- a/kernel/src/init.rs
+++ b/kernel/src/init.rs
@@ -11,7 +11,6 @@ use crate::{
     },
 };
 
-#[cfg(debug_assertions)]
 use crate::debug;
 
 lazy_static! {

--- a/kernel/src/interrupts.rs
+++ b/kernel/src/interrupts.rs
@@ -9,8 +9,7 @@ mod gdt;
 mod pic_handlers;
 pub use gdt::{reload_gdt, GDT};
 mod pic;
-mod syscalls;
-pub use syscalls::setup_syscalls;
+pub mod syscalls;
 
 use crate::debug;
 

--- a/kernel/src/interrupts/gdt.rs
+++ b/kernel/src/interrupts/gdt.rs
@@ -8,7 +8,8 @@ use crate::debug;
 
 /// the interrupt stack table index of the stack used for double faults
 pub const DOUBLE_FAULT_IST_INDEX: u16 = 0;
-pub const NMI_IST_INDEX: u16 = 0;
+pub const NMI_IST_INDEX: u16 = 1;
+pub const TIMER_IST_INDEX: u16 = 2;
 
 lazy_static! {
     /// The TSS of the OS.
@@ -44,6 +45,17 @@ lazy_static! {
         };
 
         tss.interrupt_stack_table[NMI_IST_INDEX as usize] = {
+
+            static mut STACK: Stack = Stack([0; STACK_SIZE]);
+
+            let stack_start = VirtAddr::from_ptr(unsafe { &STACK });
+
+            // returns the highest address of the stack because the stack grows downwards
+            let stack_end = stack_start + STACK_SIZE;
+            stack_end
+        };
+
+        tss.interrupt_stack_table[TIMER_IST_INDEX as usize] = {
 
             static mut STACK: Stack = Stack([0; STACK_SIZE]);
 

--- a/kernel/src/interrupts/pic.rs
+++ b/kernel/src/interrupts/pic.rs
@@ -1,4 +1,5 @@
 use pic8259::ChainedPics;
+use spin::Mutex;
 
 pub const PIC_1_OFFSET: u8 = 32;
 pub const PIC_2_OFFSET: u8 = PIC_1_OFFSET + 8;
@@ -28,7 +29,7 @@ impl InterruptIndex {
 }
 
 /// The PICs of the system.
-pub static PICS: spin::Mutex<ChainedPics> = spin::Mutex::new(unsafe {
+pub static PICS: Mutex<ChainedPics> = Mutex::new(unsafe {
     // this is unsafe, because wrong offsets will cause undefined behavior
     ChainedPics::new(PIC_1_OFFSET, PIC_2_OFFSET)
 });

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -29,12 +29,10 @@ use crate::logger::Logger;
 mod interrupts;
 mod user_mode;
 pub use user_mode::run_in_user_mode;
+mod debug;
 pub mod logger;
 mod memory;
 pub mod structures;
-
-#[cfg(debug_assertions)]
-mod debug;
 
 lazy_static! {
     pub static ref LOGGER: Arc<Mutex<Option<Box<dyn Logger>>>> = Arc::from(Mutex::new(None));

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -22,7 +22,7 @@ use test_framework::{
 };
 
 mod init;
-pub use init::{hlt_loop, init, register_driver, register_syscall, reload_drivers};
+pub use init::{hlt_loop, init, register_driver, reload_drivers};
 
 use crate::logger::Logger;
 
@@ -32,6 +32,7 @@ pub use user_mode::run_in_user_mode;
 mod debug;
 pub mod logger;
 mod memory;
+pub mod processes;
 pub mod structures;
 
 lazy_static! {

--- a/kernel/src/processes.rs
+++ b/kernel/src/processes.rs
@@ -1,0 +1,2 @@
+mod registers_state;
+pub use registers_state::RegistersState;

--- a/kernel/src/processes/registers_state.rs
+++ b/kernel/src/processes/registers_state.rs
@@ -1,0 +1,53 @@
+use x86_64::VirtAddr;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct RegistersState {
+    pub r15: u64,
+    pub r14: u64,
+    pub r13: u64,
+    pub r12: u64,
+    pub r11: u64,
+    pub r10: u64,
+    pub r9: u64,
+    pub r8: u64,
+    pub rdi: u64,
+    pub rsi: u64,
+    pub rbp: u64,
+    pub rdx: u64,
+    pub rcx: u64,
+    pub rbx: u64,
+    pub rax: u64,
+    pub rip: VirtAddr,
+    pub cs: u64,
+    pub rflags: u64,
+    pub rsp: VirtAddr,
+    pub ss: u64,
+}
+
+impl RegistersState {
+    pub fn new(rip: VirtAddr, rflags: u64, rsp: VirtAddr) -> Self {
+        RegistersState {
+            r15: 0,
+            r14: 0,
+            r13: 0,
+            r12: 0,
+            r11: 0,
+            r10: 0,
+            r9: 0,
+            r8: 0,
+            rdi: 0,
+            rsi: 0,
+            rbp: 0,
+            rdx: 0,
+            rcx: 0,
+            rbx: 0,
+            rax: 0,
+            rip,
+            cs: 0,
+            rflags,
+            rsp,
+            ss: 0,
+        }
+    }
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -4,29 +4,60 @@
 #![feature(generic_const_exprs, core_intrinsics)]
 
 use alloc::{format, string::String};
+use core::arch::asm;
 
 extern crate alloc;
 pub mod array_combiner;
 pub mod byte_reader;
 pub mod constants;
+use crate::constants::{GIB, KIB, MIB};
 pub mod port_extensions;
 pub mod static_stack;
 pub mod syscall_name;
 
-pub const KIBIBYTE: u64 = 1024;
-pub const MEBIBYTE: u64 = KIBIBYTE * 1024;
-pub const GIBIBYTE: u64 = MEBIBYTE * 1024;
-
+/// Formats the size in bytes to a human readable string.
 pub fn format_size(bytes: u64) -> String {
     match bytes {
-        b if b < KIBIBYTE => format!("{}B", b),
-        b if b < MEBIBYTE => format!("{}KiB", b / KIBIBYTE),
-        b if b < GIBIBYTE => format!("{}MiB", b / MEBIBYTE),
-        b => format!("{}GiB", b / GIBIBYTE),
+        b if b < KIB => format!("{}B", b),
+        b if b < MIB => format!("{}KiB", b / KIB),
+        b if b < GIB => format!("{}MiB", b / MIB),
+        b => format!("{}GiB", b / GIB),
     }
 }
 
+#[macro_export]
+/// Macro for pushing all registers onto the stack.
+macro_rules! push_all {
+    () => {
+        "push rax;push rbx;push rcx;push rdx;push rbp;push rsi;push rdi;push r8;push r9;push r10;push r11;push r12;push r13;push r14;push r15"
+    };
+}
+
+#[macro_export]
+/// Macro for popping all registers from the stack.
+macro_rules! pop_all {
+    () => {
+        "pop r15;pop r14;pop r13;pop r12;pop r11;pop r10;pop r9;pop r8;pop rdi;pop rsi;pop rbp;pop rdx;pop rcx;pop rbx;pop rax"
+    };
+}
+
 #[inline(always)]
+/// Returns the current CPU tick. May be off a bit.
+pub fn get_current_tick() -> u64 {
+    let start_tick_low: u32;
+    let start_tick_high: u32;
+    unsafe {
+        asm!(
+            "rdtsc",
+            out("eax")(start_tick_low),
+            out("edx")(start_tick_high)
+        );
+    }
+    u64::from(start_tick_low) | (u64::from(start_tick_high) << 32)
+}
+
+#[inline(always)]
+/// Fast division by 255 using additions and shifts.
 pub fn div_255_fast(x: u16) -> u8 {
     (((x) + (((x) + 257) >> 8)) >> 8) as u8
 }

--- a/utils/src/static_stack.rs
+++ b/utils/src/static_stack.rs
@@ -1,4 +1,4 @@
-/// A fixed size stack.
+/// A stack with a fixed size.
 pub struct StaticStack<T: Sized + Default + Clone + Copy, const C: usize> {
     buffer: [T; C],
     top: usize,
@@ -8,6 +8,7 @@ pub struct StaticStack<T: Sized + Default + Clone + Copy, const C: usize> {
 #[derive(Debug)]
 #[repr(u8)]
 pub enum StaticStackError {
+    /// The stack is full.
     EOS,
 }
 

--- a/utils/src/syscall_name.rs
+++ b/utils/src/syscall_name.rs
@@ -1,6 +1,6 @@
 #[repr(u64)]
 #[derive(Debug)]
 pub enum SysCallName {
-    Debug = 0,
-    SecondDebug = 1,
+    FirstProcess = 0,
+    SecondProcess = 1,
 }


### PR DESCRIPTION
Restructurized parts of the kernel to make imports clearer
Added RegistersState struct for storing full thread register state
Added separate stack for timer interrupt
Moved syscall static to syscalls.rs
Fixed rsp being popped from the stack then being decremented
Added push/pop all macros
Added function to get current cpu tick
Added SysCallName enum