### PR TITLE
Improved scheduler design

### DIFF
--- a/kernel/src/interrupts/pic_handlers/timer.rs
+++ b/kernel/src/interrupts/pic_handlers/timer.rs
@@ -25,20 +25,7 @@ extern "C" fn timer_interrupt_handler(registers_state: *const RegistersState) {
     let tick = get_current_tick();
 
     with_kernel_memory(|| {
-        {
-            if let Some(thread) = get_scheduler().running_thread.clone() {
-                {
-                    let mut thread_mut = thread.borrow_mut();
-
-                    thread_mut.registers_state = registers_state;
-                    thread_mut.total_ticks += tick - thread_mut.last_tick;
-                    thread_mut.last_tick = tick;
-                    let mut process = thread_mut.process.borrow_mut();
-                    process.total_ticks += tick - process.last_tick;
-                    process.last_tick = tick;
-                }
-            }
-        }
+        get_scheduler().timer_tick(registers_state, tick);
         unsafe {
             PICS.lock()
                 .notify_end_of_interrupt(InterruptIndex::Timer.as_u8());

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -2,6 +2,7 @@
 #![no_main]
 #![allow(incomplete_features)]
 #![feature(
+    option_get_or_insert_default,
     abi_x86_interrupt,
     generic_const_exprs,
     core_intrinsics,

--- a/kernel/src/processes.rs
+++ b/kernel/src/processes.rs
@@ -2,11 +2,9 @@ pub mod dispatcher;
 
 mod memory_mapper;
 
-mod process;
-pub use process::Process;
+pub mod process;
 
-mod thread;
-pub use thread::Thread;
+pub mod thread;
 
 mod registers_state;
 pub use registers_state::RegistersState;

--- a/kernel/src/processes/thread.rs
+++ b/kernel/src/processes/thread.rs
@@ -4,14 +4,26 @@ use alloc::rc::Rc;
 use internal_utils::get_current_tick;
 use x86_64::VirtAddr;
 
-use super::Process;
+use super::process::Process;
 
+use super::dispatcher::remove_thread_from_process_queues;
 use super::RegistersState;
+
+#[derive(Debug, Clone)]
+pub enum ThreadState {
+    NotStarted,
+    Ready,
+    Running,
+    Sleeping(u64),
+    Terminated,
+}
 
 #[derive(Debug)]
 pub struct Thread {
     /// The thread's ID (in-process).
     pub id: u64,
+    /// The thread's current state.
+    pub state: ThreadState,
     /// The state of the registers.
     pub registers_state: RegistersState,
     /// Total ticks the thread has been running for.
@@ -31,6 +43,30 @@ impl Thread {
         self.total_ticks * 100 / ticks_maximum
     }
 
+    pub fn change_state(thread: Rc<RefCell<Thread>>, state: ThreadState) {
+        {
+            let borrowed_thread = thread.borrow();
+            let mut borrowed_process = borrowed_thread.process.borrow_mut();
+            remove_thread_from_process_queues(
+                &borrowed_thread,
+                thread.clone(),
+                &mut borrowed_process,
+            );
+        }
+        let mut borrowed_thread = thread.borrow_mut();
+        borrowed_thread.state = state;
+        {
+            let mut borrowed_process = borrowed_thread.process.borrow_mut();
+            match borrowed_thread.state {
+                ThreadState::NotStarted => borrowed_process.not_started_threads.push(thread.clone()),
+                ThreadState::Ready => borrowed_process.ready_threads.push(thread.clone()),
+                ThreadState::Running => panic!("Trying to change a thread to running state - use dispatcher::switch_to_thread() instead"),
+                ThreadState::Sleeping(_) => borrowed_process.sleeping_threads.push(thread.clone()),
+                ThreadState::Terminated => {}
+            }
+        }
+    }
+
     /// Creates a new thread with the given starting address and stack pointer.
     pub fn new(
         address: u64,
@@ -38,7 +74,13 @@ impl Thread {
         process: Rc<RefCell<Process>>,
     ) -> Rc<RefCell<Self>> {
         let thread = Thread {
-            id: process.borrow().threads.len() as u64,
+            id: {
+                let process = process.borrow();
+                process.not_started_threads.len()
+                    + process.ready_threads.len()
+                    + process.sleeping_threads.len()
+            } as u64,
+            state: ThreadState::NotStarted,
             total_ticks: 0,
             start_tick: get_current_tick(),
             last_tick: 0,
@@ -50,7 +92,7 @@ impl Thread {
             ),
         };
         let rc = Rc::new(RefCell::new(thread));
-        process.borrow_mut().threads.push(rc.clone());
+        process.borrow_mut().not_started_threads.push(rc.clone());
         rc
     }
 }

--- a/rost-lib/src/thread_utils.rs
+++ b/rost-lib/src/thread_utils.rs
@@ -1,16 +1,16 @@
+use core::cell::RefCell;
+
+use alloc::rc::Rc;
 use kernel::processes::dispatcher::exit_thread;
-use kernel::processes::{get_scheduler, run_next_thread};
+use kernel::processes::run_next_thread;
+use kernel::processes::thread::Thread;
 
 use crate::syscall_name::SysCallName;
 
-pub(crate) extern "C" fn thread_exit(code: u64, _: u64) -> u64 {
-    let scheduler = get_scheduler();
-    if let Some(thread) = scheduler.running_thread.clone() {
-        exit_thread(thread).unwrap();
-        run_next_thread();
-        panic!("No threads to run");
-    }
-    code
+pub(crate) extern "C" fn thread_exit(code: u64, _: u64, caller: Rc<RefCell<Thread>>) -> u64 {
+    exit_thread(caller).unwrap();
+    run_next_thread();
+    panic!("No threads to run");
 }
 
 pub extern "C" fn exit(status: u64) -> ! {

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,10 +93,16 @@ pub extern "C" fn exit(status: u64) -> ! {
 }
 
 pub fn kernel_main(kernel_info: KernelInformation) {
-    use kernel::processes::{add_process, run_processes, Process, Thread};
+    use kernel::processes::{
+        add_process,
+        process::Process,
+        run_processes,
+        thread::{Thread, ThreadState},
+    };
 
     let process1 = add_process(Process::new(user_mode_check_1, 1));
-    let _thread1 = Thread::new(0x1000, 2 * MIB, process1);
+    let thread1 = Thread::new(0x1000, 2 * MIB, process1);
+    Thread::change_state(thread1, ThreadState::Ready);
 
     //let process2 = add_process(Process::new(user_mode_check_2, 2));
     //let _thread2 = Thread::new(0x1000, 2 * MIB, process2);
@@ -162,7 +168,7 @@ fn alloc_error_handler(layout: Layout) -> ! {
 pub fn panic_handler(info: &PanicInfo) -> ! {
     use test_framework::ansi_colors;
 
-    serial_println!("{}\n", ansi_colors::Red("[PANIC]"));
+    serial_println!("{}", ansi_colors::Red("[PANIC]"));
     serial_println!("Error: {}\n", info);
     kernel::hlt_loop();
 }
@@ -175,7 +181,7 @@ pub fn test_panic_handler(info: &PanicInfo) -> ! {
         qemu_exit::{exit_qemu, QemuExitCode},
     };
 
-    serial_println!("{}\n", ansi_colors::Red("[PANIC]"));
+    serial_println!("{}", ansi_colors::Red("[PANIC]"));
     serial_println!("Error: {}\n", info);
     exit_qemu(QemuExitCode::Failed);
 


### PR DESCRIPTION
- Made syscall handlers pass a reference to the calling thread.
- Added separate queues for sleeping and not-started threads in the process.
- Added auto-moving the sleeping threads into the ready queue.
- Added change_state method for safely changing the thread state.

Closes #33 